### PR TITLE
Fix saga connection with zerorpc calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "concurrently --kill-others 'yarn run start-react' 'yarn run start-electron'",
     "start-electron": "electron .",
     "start-react": "cross-env BROWSER=none react-app-rewired start",
-    "start-python": "python src/python/rpc.py",
+    "python": "python src/python/rpc.py",
     "build-react": "react-app-rewired build",
     "build-electron": "electron build",
     "test": "react-app-rewired test --env=jsdom",

--- a/src/components/MainForm.js
+++ b/src/components/MainForm.js
@@ -2,29 +2,22 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   Button,
-  Collapse,
   Upload,
   Checkbox,
   Icon,
   Input,
   Form,
-  Switch,
   Select,
-  Typography,
-  Modal,
-  Tabs,
   message
 } from 'antd';
 
-// const { Upload } = Upload;
-const { Paragraph } = Typography;
-const { Panel } = Collapse;
-const { TabPane } = Tabs;
 const { Option } = Select;
 
 const requirePassphrase = algo => ['AES', 'Blowfish'].includes(algo);
 
-@connect(({ rpc }) => ({}))
+@connect(({ rpc }) => ({
+  running: rpc.running
+}))
 @Form.create()
 class MainForm extends React.Component {
   state = {
@@ -93,8 +86,7 @@ class MainForm extends React.Component {
     const { fileList, keyFile, folderList } = this.state;
     this.props.form.validateFields((err, values) => {
       if (!err) {
-        const { algo, encrypt, passphrase } = values;
-        const type = encrypt ? 'rpc/encrypt' : 'rpc/decrypt';
+        const { algo, encrypt } = values;
         let key;
 
         // if (requirePassphrase(algo)) key = passphrase;
@@ -103,13 +95,14 @@ class MainForm extends React.Component {
         console.log(fileList);
         console.log(folderList);
         dispatch({
-          type,
+          type: 'rpc/invoke',
           payload: {
             fileList: fileList
               .map(f => f.path)
               .concat(folderList.map(f => f.path)),
             key,
-            algo
+            algo,
+            task: encrypt ? 'encrypt' : 'decrypt'
           }
         });
       }
@@ -117,7 +110,8 @@ class MainForm extends React.Component {
   };
 
   render() {
-    const { algorithm, keyFile, fileList, folderList } = this.state;
+    const { running } = this.props;
+    const { keyFile, fileList, folderList } = this.state;
     const { getFieldDecorator } = this.props.form;
 
     return (
@@ -210,22 +204,6 @@ class MainForm extends React.Component {
           )}
         </Form.Item>
 
-        {/* <Form.Item label="passphrase">
-          {getFieldDecorator('passphrase', {
-            rules: [
-              {
-                // required: requirePassphrase(algorithm),
-                message: 'The algorithm chosen requires a passphrase'
-              }
-            ]
-          })(
-            <Input
-              // disabled={!requirePassphrase(algorithm)}
-              style={{ width: '100%' }}
-            />
-          )}
-        </Form.Item> */}
-
         <Form.Item>
           {getFieldDecorator('encrypt', {
             valuePropName: 'encrypt'
@@ -233,8 +211,8 @@ class MainForm extends React.Component {
         </Form.Item>
 
         <Form.Item>
-          <Button type="primary" htmlType="submit">
-            Submit
+          <Button type="primary" htmlType="submit" loading={running > 0}>
+            {running > 0 ? `${running} task(s) running` : `Submit`}
           </Button>
         </Form.Item>
       </Form>

--- a/src/python/AES.py
+++ b/src/python/AES.py
@@ -1,7 +1,8 @@
 from Crypto.Cipher import AES
-import hashlib
-import sys
+
 import os
+import hashlib
+import gevent
 
 
 class AESCipher:
@@ -20,6 +21,10 @@ class AESCipher:
             _key = bytes.fromhex(open(key, 'r').read())
         else:
             _key = hashlib.sha256(key.encode()).digest()
+
+        num_block = os.path.getsize(file_path) // 128
+        round = 0
+
         cipher = AES.new(_key, AES.MODE_CFB, self.iv)
         while True:
             a = file.read(128)
@@ -27,6 +32,8 @@ class AESCipher:
                 break
             cipher_text = cipher.encrypt(a)
             out_file.write(cipher_text)
+            yield "{}/{}".format(round, num_block)
+            round += 1
 
         file.close()
         out_file.close()
@@ -40,6 +47,10 @@ class AESCipher:
             _key = bytes.fromhex(open(key, 'r').read())
         else:
             _key = hashlib.sha256(key.encode()).digest()
+
+        num_block = os.path.getsize(file_path) // 128
+        round = 0
+
         cipher = AES.new(_key, AES.MODE_CFB, self.iv)
         while True:
             a = file.read(128)
@@ -47,5 +58,8 @@ class AESCipher:
                 break
             cipher_text = cipher.decrypt(a)
             out_file.write(cipher_text)
+            yield "{}/{}".format(round, num_block)
+            round += 1
+
         file.close()
         out_file.close()

--- a/src/python/Blowfish.py
+++ b/src/python/Blowfish.py
@@ -2,6 +2,7 @@ from Crypto import Random
 from Crypto.Cipher import Blowfish
 
 import os
+import gevent
 
 
 class BlowfishCipher:
@@ -40,6 +41,9 @@ class BlowfishCipher:
             encode = iv + cipher.encrypt(chunk)
         outfile.write(encode)
 
+        num_block = os.path.getsize(originalFile) // chunk_size
+        round = 0
+
         while True:
             chunk = infile.read(chunk_size)
             if not chunk:
@@ -49,6 +53,8 @@ class BlowfishCipher:
             else:
                 encode = cipher.encrypt(chunk)
             outfile.write(encode)
+            yield "{}/{}".format(round, num_block)
+            round += 1
 
         infile.close()
         outfile.close()
@@ -68,6 +74,9 @@ class BlowfishCipher:
         iv = ifile.read(bs)
         cipher = Blowfish.new(key, Blowfish.MODE_CBC, iv)
 
+        num_block = os.path.getsize(encryptedFile) // chunk_size
+        round = 0
+
         while True:
             chunk = ifile.read(chunk_size)
             encode = ''
@@ -78,13 +87,8 @@ class BlowfishCipher:
             else:
                 encode = cipher.decrypt(chunk)
             ofile.write(encode)
+            yield "{}/{}".format(round, num_block)
+            round += 1
 
         ifile.close()
         ofile.close()
-
-
-if __name__ == "__main__":
-    a = BlowfishCipher()
-    a.encrypt('testfile.zip', '12345678', 'test.enc')
-    a.decrypt('test.enc', '12345678', 'hbeat12345.zip')
-    print('done')

--- a/src/python/RSA.py
+++ b/src/python/RSA.py
@@ -2,6 +2,7 @@ from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
 
 import os
+import gevent
 
 
 class RSACipher:
@@ -48,13 +49,14 @@ class RSACipher:
         round = 0
 
         while True:
-            # print("{}: Round {} of {}".format(cipher_file, round, num_block))
-            round += 1
             a = cf.read(block_size)
             if not a:
                 break
             cipher_text = cipher.encrypt(a)
             ef.write(cipher_text)
+            yield "{}/{}".format(round, num_block)
+            round += 1
+
         cf.close()
         kf.close()
         ef.close()
@@ -71,13 +73,14 @@ class RSACipher:
         round = 0
 
         while True:
-            # print("{}: Round {} of {}".format(cipher_file, round, num_block))
-            round += 1
             a = cf.read(block_size)
             if not a:
                 break
             plain_text = cipher.decrypt(a)
             ef.write(plain_text)
+            yield "{}/{}".format(round, num_block)
+            round += 1
+
         cf.close()
         kf.close()
         ef.close()

--- a/src/reducers/rpc.js
+++ b/src/reducers/rpc.js
@@ -39,6 +39,16 @@ const rpcReducer = (state = {}, { type, payload }) => {
         key: payload.key,
         createKeySuccess: payload.success
       });
+    case 'rpc/addRunning':
+      return Object.assign({}, state, {
+        ...state,
+        running: state.running + 1
+      });
+    case 'rpc/removeRunning':
+      return Object.assign({}, state, {
+        ...state,
+        running: state.running - 1
+      });
     default:
       return state;
   }

--- a/src/sagas/rpc.js
+++ b/src/sagas/rpc.js
@@ -11,11 +11,15 @@ import {
 import { message } from 'antd';
 
 const rpc_callback = (err, res, more) => {
+  if (err) {
+    console.log(err);
+    message.error('Error calling RPC');
+    return;
+  }
   if (!more) {
-    console.log(res);
-    console.log('done');
+    message.success('Done');
   } else {
-    console.log(res);
+    // console.log(res);
   }
 };
 

--- a/src/store.js
+++ b/src/store.js
@@ -7,11 +7,11 @@ import rootSaga from '@/sagas';
 const remote = window.require('electron').remote;
 const zerorpc = remote.require('zerorpc');
 
-const client = new zerorpc.Client();
+const client = new zerorpc.Client({});
 client.connect('tcp://127.0.0.1:4242');
 
 const initialState = {
-  rpc: { zerorpc: client, key: [], createKeySuccess: false },
+  rpc: { zerorpc: client, key: [], createKeySuccess: false, running: 0 },
   route: { current: 'Home' }
 };
 


### PR DESCRIPTION
This pull request introduce:
- Loading status
- Handling of timeout by fast response on rpc
- Handling of remote connection better using `gevent.sleep(0)`
- Saga call on rpc is now `rpc/invoke` with `payload.task` to define 'encrypt/decrypt'.
- Simple handling of Ctrl+C on Server, no wait task stop.

How?

On handling heartbeat, gevent must be sleep to turn to another task (heartbeat ping), so after every round of decryption/encryption, gevent.sleep(0) should be called.

On handling timeout of long calls, zerorpc wait for first message for 30s, after that if no message is given, exception is called. To make this work for long calls, turn method to stream and yield first.

On loading status,
- Set a running variable on store to indicate running task.
- Because our Server open 5 pool, so at most 5 task can be run simultaneously. To prevent more than 5 task running, 2 solutions: 1. Implement server queue, 2. Implement client queue. I choose to work on client queue, it is more pleasant.
